### PR TITLE
✨ feat: Add sl1 loss, zero-one, round etc

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+from email.policy import default
 import time
 import argparse
 import pandas as pd
@@ -85,6 +86,15 @@ def main(args):
             pass
 
         ######################## TRAIN
+        if args.ZEROONE:
+            print('zeroone')
+        else:
+            print('no zeroone')
+
+        if args.LOSS == 'sl1':
+            print('with sl1 loss beta', args.BETA)
+        elif args.LOSS == 'rmse':
+            print('with rmse loss')
         print(f'--------------- {args.MODEL} TRAINING ---------------')
         model.train(fold_num = 0)
 
@@ -103,7 +113,10 @@ def main(args):
         print(f'--------------- SAVE {args.MODEL} PREDICT ---------------')
         submission = pd.read_csv(args.DATA_PATH + 'ratings/sample_submission.csv')
         if args.MODEL in ('FM', 'FFM', 'NCF', 'WDN', 'DCN', 'CNN_FM', 'DeepCoNN', 'XGB', 'LGBM', 'CATB'):
-            submission['rating'] = predicts
+            if args.ZEROONE: # 0. ~ 1 스케일링 시
+                submission['rating'] = [p * 10 for p in predicts]
+            else:
+                submission['rating'] = [p for p in predicts]
         else:
             pass
 
@@ -112,6 +125,11 @@ def main(args):
         length = len(data['test'])
         kfold_predicts = np.zeros((args.N_SPLITS, length))
         rmse_array = np.zeros(args.N_SPLITS)
+
+        if args.LOSS == 'sl1':
+            print('with sl1 loss beta', args.BETA)
+        elif args.LOSS == 'rmse':
+            print('with rmse loss')
 
         if args.MODEL in ('FM', 'FFM', 'XGB', 'LGBM', 'CATB'):
             for idx, (train_index, valid_index) in enumerate(skf.split(
@@ -146,12 +164,19 @@ def main(args):
                 print(f'--------------- FOLD-{idx}, {args.MODEL} PREDICT ---------------')
                 kfold_predicts[idx] = np.array(model.predict(data['test_dataloader']))
             
+            
+            
             print(f'--------------- FOLD-{idx}, SAVE {args.MODEL} PREDICT ---------------')
             predicts = np.mean(kfold_predicts, axis = 0).tolist()
+            # 평균 내기 전에 복구할까 평균 내고 복구할까? 일단 평균 내고 복구한다.
             submission = pd.read_csv(args.DATA_PATH + 'ratings/sample_submission.csv')
             print(f"[5-FOLD VALIDATION MEAN RMSE SCORE]: {rmse_array.mean()}")
             if args.MODEL in ('FM', 'FFM', 'NCF', 'WDN', 'DCN', 'CNN_FM', 'DeepCoNN'):
-                submission['rating'] = predicts
+                if args.ZEROONE: # 0. ~ 1 스케일링 시
+                    submission['rating'] = submission['rating'] = [p * 10 for p in predicts]
+                else:
+                    submission['rating'] = [p for p in predicts]
+                # submission['rating'] = predicts
             else:
                 pass
         
@@ -187,7 +212,10 @@ def main(args):
             submission = pd.read_csv(args.DATA_PATH + 'ratings/sample_submission.csv')
             print(f"[5-FOLD VALIDATION MEAN RMSE SCORE]: {rmse_array.mean()}")
             if args.MODEL in ('FM', 'FFM', 'NCF', 'WDN', 'DCN', 'CNN_FM', 'DeepCoNN', 'XGB', 'LGBM', 'CATB'):
-                submission['rating'] = predicts
+                if args.ZEROONE: # 0. ~ 1 스케일링 시
+                    submission['rating'] = [p * 10 for p in predicts]
+                else:
+                    submission['rating'] = [p for p in predicts]
             else:
                 pass
         
@@ -254,8 +282,11 @@ def main(args):
     now_hour = time.strftime('%X', now)
     save_time = now_date + '_' + now_hour.replace(':', '')
     print(f"[SUBMISSION NAME] {save_time}_{args.MODEL} @@@@")
+    if args.ROUND: # 라운드 된 것 안된 것 둘다 저장하기.
+        submission_r = submission.copy()
+        submission_r['rating'] = submission_r['rating'].apply(np.round)
+        submission_r.to_csv('/opt/ml/data/submit/{}_{}_r.csv'.format(save_time, args.MODEL),index=False)
     submission.to_csv('/opt/ml/data/submit/{}_{}.csv'.format(save_time, args.MODEL), index=False)
-    
 
 
 
@@ -284,6 +315,14 @@ if __name__ == "__main__":
     arg('--LR', type=float, default=1e-4, help='Learning Rate를 조정할 수 있습니다.')
     arg('--WEIGHT_DECAY', type=float, default=1e-5, help='Adam optimizer에서 정규화에 사용하는 값을 조정할 수 있습니다.')
     arg('--PATIENCE', type = int, default = 3, help = 'Early Stop patience')
+    arg('--ZEROONE', type=bool, default=False, help = '0. ~ 1 스케일링 합니다.')
+    arg('--ROUND', type=bool, default=False, help = '점수 반올림 진행합니다.')
+
+
+    ############### Loss Func
+    arg('--LOSS', type=str, default='rmse', help='rmse, sl1, huber')
+    arg('--BETA', type=float, default=1.0, help='smooth l1, hubor 에서 베타, 델타 지정합니다.(0 ~ 1)')
+
 
     ############### GPU
     arg('--DEVICE', type=str, default='cuda', choices=['cuda', 'cpu'], help='학습에 사용할 Device를 조정할 수 있습니다.')

--- a/src/data/context_data.py
+++ b/src/data/context_data.py
@@ -184,15 +184,18 @@ def context_data_loader(args, data):
             (data['X_train'], data['y_train']), (data['X_valid'], data['y_valid']), (data['test'], None)
     
     else:
-        train_dataset = TensorDataset(torch.LongTensor(data['X_train'].values), torch.LongTensor(data['y_train'].values))
-        valid_dataset = TensorDataset(torch.LongTensor(data['X_valid'].values), torch.LongTensor(data['y_valid'].values))
-        test_dataset = TensorDataset(torch.LongTensor(data['test'].values))
-
+        if args.ZEROONE:
+            train_dataset = TensorDataset(torch.LongTensor(data['X_train'].values), torch.FloatTensor(data['y_train'].values) / 10.0)
+            valid_dataset = TensorDataset(torch.LongTensor(data['X_valid'].values), torch.FloatTensor(data['y_valid'].values) / 10.0)
+        else:
+            train_dataset = TensorDataset(torch.LongTensor(data['X_train'].values), torch.FloatTensor(data['y_train'].values))
+            valid_dataset = TensorDataset(torch.LongTensor(data['X_valid'].values), torch.FloatTensor(data['y_valid'].values))
+    test_dataset = TensorDataset(torch.LongTensor(data['test'].values))
     
-        train_dataloader = DataLoader(train_dataset, batch_size=args.BATCH_SIZE, shuffle=args.DATA_SHUFFLE, num_workers = 4)
-        valid_dataloader = DataLoader(valid_dataset, batch_size=args.BATCH_SIZE, shuffle=args.DATA_SHUFFLE, num_workers = 4)
-        test_dataloader = DataLoader(test_dataset, batch_size=args.BATCH_SIZE, shuffle=False, num_workers = 4)
+    train_dataloader = DataLoader(train_dataset, batch_size=args.BATCH_SIZE, shuffle=args.DATA_SHUFFLE, num_workers = 4)
+    valid_dataloader = DataLoader(valid_dataset, batch_size=args.BATCH_SIZE, shuffle=args.DATA_SHUFFLE, num_workers = 4)
+    test_dataloader = DataLoader(test_dataset, batch_size=args.BATCH_SIZE, shuffle=False, num_workers = 4)
 
-        data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = train_dataloader, valid_dataloader, test_dataloader
+    data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = train_dataloader, valid_dataloader, test_dataloader
 
     return data

--- a/src/data/dl_data.py
+++ b/src/data/dl_data.py
@@ -170,8 +170,18 @@ def dl_data_split(args, data):
     return data
 
 def dl_data_loader(args, data):
-    train_dataset = TensorDataset(torch.LongTensor(data['X_train'].values), torch.LongTensor(data['y_train'].values))
-    valid_dataset = TensorDataset(torch.LongTensor(data['X_valid'].values), torch.LongTensor(data['y_valid'].values))
+#     print(torch.LongTensor(data['X_train'].values))
+#     print('e')
+#     print(torch.FloatTensor(data['y_train'].values) / 10.0)
+#     raise 'ok'
+
+    if args.ZEROONE:
+        train_dataset = TensorDataset(torch.LongTensor(data['X_train'].values), torch.FloatTensor(data['y_train'].values) / 10.0)
+        valid_dataset = TensorDataset(torch.LongTensor(data['X_valid'].values), torch.FloatTensor(data['y_valid'].values) / 10.0)
+    else:
+        train_dataset = TensorDataset(torch.LongTensor(data['X_train'].values), torch.FloatTensor(data['y_train'].values))
+        valid_dataset = TensorDataset(torch.LongTensor(data['X_valid'].values), torch.FloatTensor(data['y_valid'].values))
+    
     test_dataset = TensorDataset(torch.LongTensor(data['test'].values))
 
     train_dataloader = DataLoader(train_dataset, batch_size=args.BATCH_SIZE, shuffle=args.DATA_SHUFFLE, num_workers = 4)

--- a/src/models/_models.py
+++ b/src/models/_models.py
@@ -19,6 +19,17 @@ class RMSELoss(torch.nn.Module):
         return loss
 
 
+class SmoothL1Loss(torch.nn.Module):
+    def __init__(self, beta):
+        self.beta = beta
+        super(SmoothL1Loss,self).__init__()
+
+    def forward(self, x, y):
+        criterion = nn.SmoothL1Loss(beta=self.beta)
+        loss = criterion(x, y)
+        return loss
+
+
 class FactorizationMachine(nn.Module):
 
     def __init__(self, reduce_sum:bool=True):

--- a/src/models/context_models.py
+++ b/src/models/context_models.py
@@ -85,7 +85,10 @@ class FactorizationMachineModel:
                 y = self.model(fields)
                 targets.extend(target.tolist())
                 predicts.extend(y.tolist())
-        return rmse(targets, predicts)
+        if self.args.ZEROONE:
+            return rmse([t * 10.0 for t in targets], [p * 10.0 for p in predicts])
+        else:
+            return rmse(targets, predicts)
 
 
     def predict(self, dataloader):
@@ -171,7 +174,10 @@ class FieldAwareFactorizationMachineModel:
                 y = self.model(fields)
                 targets.extend(target.tolist())
                 predicts.extend(y.tolist())
-        return rmse(targets, predicts)
+        if self.args.ZEROONE:
+            return rmse([t * 10.0 for t in targets], [p * 10.0 for p in predicts])
+        else:
+            return rmse(targets, predicts)
 
 
     def predict(self, dataloader):


### PR DESCRIPTION
## 개요
시도하려다 못했던 것들을 구현

## 작업사항
zero - one 스케일링, round, s1loss 를 구현했습니다. 

## 로직
zero -one 은 베이스라인 코드가 토치롱텐서 였기때문이었어서, y 값들을 플롯텐서로 바꾸었습니다.
옵션 인자들을 추가해 적용할 수 있습니다.
로스 펑션 s1loss 추가했는데, zero-one 과 효율이 좋아보입니다.
새로운 하이퍼 파라미터 베타 0.2 로, zero-one 하여 ncf 제출 결과(u1, b5) 약간 갱신하였습니다.
라운드 적용 시 2.15에서 2.17로 떨어졌습니다.

--ZEROONE, --ROUND 는 불리언이기 때문에 --ZEROONE 1 과 같이 작성해야 합니다.

빨리 제출하고 잘라다가 또 이슈를 안했네요 죄송합니다..

zeroone 시 rmse 가 그대로 2점대에 나오는데, valid prediction 시 다시 10을 곱해 복구했기 때문입니다.
여기서의 rmse 는 kfold 등 제출 결과 동일하게 0.2 ~ 0.3 정도 낮게 나오는 것을 확인했습니다.

저 못일어나면 전화한번 주세요.. 
자기전에 FM 모델도 zeroone, sl1 로스로 돌려놓아볼 생각입니다.

sl1 은 zeroone 을 안해도 동작합니다. rmse 보다 낮게 나오는데 베타를 잘 찾아야 하며, 대충 베타도 10배 해주면 될 것 같아요
근데 sl1 은 mse 로 들어가는데, 지금 베이스라인은 rmse 이기 때문에, mae에서 mse 로 넘어가는 순간이더라도 로부스트성이 rmse 보다 낮게 나오는 것 같습니다. 로직은 쉬우니 sl1의 msr 부분을 rmse 로 바꾸는 커스터마이징을 해볼수도 있겠습니다. 